### PR TITLE
Add Required Build Dependencies to Amplify

### DIFF
--- a/amplify-git-lfs/Dockerfile
+++ b/amplify-git-lfs/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install -y \
     git \
     git-lfs \
     curl \
+    python3 \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "bash", "-c" ]


### PR DESCRIPTION
python3 and make (from build-essential) are required in the yarn linking stage