### PR TITLE
upgrade amplify image to node22

### DIFF
--- a/amplify-git-lfs/Dockerfile
+++ b/amplify-git-lfs/Dockerfile
@@ -1,5 +1,4 @@
-FROM node:20.18.0-slim
-
+FROM node:22.22.2-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
 
 # https://docs.aws.amazon.com/amplify/latest/userguide/custom-build-image.html
 RUN apt-get update && apt-get install -y \

--- a/amplify-git-lfs/Dockerfile
+++ b/amplify-git-lfs/Dockerfile
@@ -1,12 +1,23 @@
 FROM node:22.22.2-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
 
 # https://docs.aws.amazon.com/amplify/latest/userguide/custom-build-image.html
+# git is needed for turbo - without it hashes are not updated correctly
+# zip is needed for building browser extension bundles
+# node-canvas requires additional build dependencies https://github.com/Automattic/node-canvas#compiling
 RUN apt-get update && apt-get install -y \
     git \
     git-lfs \
     curl \
+    zip \
     python3 \
     build-essential \
+    pkg-config \
+    libpixman-1-dev \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
     && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "bash", "-c" ]


### PR DESCRIPTION
Upgrades amplify build image to node 22

Validation:
```
docker run --rm -it \ 
  -v "$PWD":/repo \
  -w /repo \
  amplify-image \
  bash
```

after building locally (and tagging with amplify-image) I ran the full build on our monorepo to verify it works