### PR TITLE
Enable corepack in amplify image

### DIFF
--- a/amplify-git-lfs/Dockerfile
+++ b/amplify-git-lfs/Dockerfile
@@ -20,4 +20,7 @@ RUN apt-get update && apt-get install -y \
     librsvg2-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# corepack provides the pnpm/yarn shims (bundled with node, opt-in)
+RUN corepack enable
+
 ENTRYPOINT [ "bash", "-c" ]


### PR DESCRIPTION
## What

Enable [corepack](https://nodejs.org/api/corepack.html) in the `amplify-git-lfs` image so the `pnpm`/`yarn` shims are available out of the box:

```dockerfile
RUN corepack enable
```

Corepack ships bundled with Node but is opt-in, so it needs to be enabled explicitly.

## Why

Amplify builds that use pnpm previously had no package manager shim available in the image. Enabling corepack lets builds run `pnpm` directly (and pins the version via `packageManager` in `package.json`).

## Testing

Built the image locally and verified pnpm resolves and runs:

- `pnpm --version` → `11.4.0` (corepack downloads the binary on first use)
- `which pnpm` → `/usr/local/bin/pnpm`
- `corepack --version` → `0.34.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)